### PR TITLE
FIX: Fixed incorrect removal of parallel_symbol in the hidden dimensi…

### DIFF
--- a/symbolic_tensor_graph/graph/coll_comm_matcher.py
+++ b/symbolic_tensor_graph/graph/coll_comm_matcher.py
@@ -95,7 +95,7 @@ class CommunicationMatcher:
                     matched = parallel_symbol
                     break
             if not matched is None:
-                remaining_parallel_symbols.remove(parallel_symbol)
+                remaining_parallel_symbols.remove(matched)
                 parallel_dims[matched] = cls.EndType.REDUCED, dim
 
         assert len(parallel_dims) + len(remaining_parallel_symbols) == len(


### PR DESCRIPTION
If `parallel_symbol` is not the matched symbol, it may end up in `ValueError` because it attempts to remove the wrong value.
